### PR TITLE
Store pair data with two way for old pair data

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Must have
 - Automated tests - _Done. Github action used for execution_
 - Use your creativity and build a new feature of your choice _Done. admin/ user/ pages with additional features such as dashboard_
 
-# Things TODO (current status: 90%) and Priority
+# Things TODO (current status: 95%) and Priority
 1. ~~Finish all controller request tests - VeryHigh~~
 2. ~~Add scheduled job test - VeryHigh~~
-3. Add more corner tests for MysteryMatcher - High
+3. Add more corner tests for MysteryMatcher - Mid (Other cases covered by worker and controller tests)
 4. ~~Add suspension logic for user deletion - VeryHigh~~
    ~~User has status (active and suspended), MysteryPairFinderWorker only selecting active users.~~
    ~~So, I need to convert "deletion" logic to "suspension logic"~~

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,9 +34,15 @@ class UsersController < ApplicationController
 
   def find_partners
     # Show previous partners
-    @partner_ids = MysteryPair.by_user(current_user).before_at(Date.today).order(:lunch_date).pluck(:partner_id)
+    @partner_ids = MysteryPair.by_user(current_user)
+                              .before_at(Date.today)
+                              .where.not(partner_id: current_user.id)
+                              .order(:lunch_date).pluck(:partner_id)
     @partners = User.where(id: @partner_ids)
-    @next_partner_ids = MysteryPair.by_user(current_user).after_at(Date.today).order(:lunch_date).pluck(:partner_id)
+    @next_partner_ids = MysteryPair.by_user(current_user)
+                                   .after_at(Date.today)
+                                   .where.not(partner_id: current_user.id)
+                                   .order(:lunch_date).pluck(:partner_id)
     @next_partners = User.where(id: @next_partner_ids)
     @limit_show = params[:more].present? ? @partners.size : 10
   end

--- a/app/workers/mystery_pair_finder_worker.rb
+++ b/app/workers/mystery_pair_finder_worker.rb
@@ -19,6 +19,9 @@ class MysteryPairFinderWorker < ActiveJob::Base
 
   # Job executes at 1st day of each month, so Date.today will be 1st day of that month
   def create_pair_data!(user, partner)
-    MysteryPair.create!(user_id: user[:id], partner_id: partner[:id], lunch_date: Date.today + 1.month)
+    ActiveRecord::Base.transaction do
+      MysteryPair.create!(user_id: user[:id], partner_id: partner[:id], lunch_date: Date.today + 1.month)
+      MysteryPair.create!(user_id: partner[:id], partner_id: user[:id], lunch_date: Date.today + 1.month)
+    end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,19 +2,22 @@ include FactoryBot::Syntax::Methods
 
 create_list(:user, 100, password: '!QAZ2wsx')
 
-# TODO: Resolve duplicated code with mystery pair worker
-
+# Create old pair data
 def create_pair_data!(user, partner)
-  MysteryPair.create!(user_id: user[:id], partner_id: partner[:id], lunch_date: Date.today)
+  MysteryPair.create!(user_id: user[:id], partner_id: partner[:id], lunch_date: 1.month.ago)
+  MysteryPair.create!(user_id: partner[:id], partner_id: user[:id], lunch_date: 1.month.ago)
 end
 
 matcher = MysteryMatcher.new(User.active)
 matcher.find_mystery_pairs.each { |user, partner| create_pair_data!(user, partner) }
 partner1, partner2, odd_user = matcher.take_care_odd_user
-return if partner1.nil?
+unless partner1.nil?
+  create_pair_data!(odd_user, partner1)
+  create_pair_data!(odd_user, partner2)
+end
 
-create_pair_data!(odd_user, partner1)
-create_pair_data!(odd_user, partner2)
+# Create future mystery pairs
+MysteryPairFinderWorker.perform_now
 
 puts '-------- ADMIN USER INFO -----------'
 admin = User.active.sample

--- a/spec/workers/mystery_pair_finder_worker_spec.rb
+++ b/spec/workers/mystery_pair_finder_worker_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe MysteryPairFinderWorker, type: :worker do
       it 'will create pair data for next month' do
         expect { subject }.not_to raise_error
         expect(MysteryPair.after_at(Date.today).present?).to be(true)
+        expect(MysteryPair.count).to eq(10) # 2 way data e.g A-B, B-A
       end
     end
 
@@ -22,6 +23,7 @@ RSpec.describe MysteryPairFinderWorker, type: :worker do
         expect { subject }.not_to raise_error
         pairs_by_group = MysteryPair.after_at(Date.today).group(:partner_id).count
         expect(pairs_by_group.values.include?(2)).to be(true)
+        expect(MysteryPair.count).to eq(14)
       end
     end
 


### PR DESCRIPTION
Store user and pair data both way. This will make easier to check any user has any partner. Otherwise complex selection required to retrieve user's partner data.